### PR TITLE
Maintain a consistent format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,121 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros: 
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The tests are in the tests/ folder
 $ make tests
 ```
 
+### Code Style
+This project uses `clang-format` to autoformat the code and maintain a consisten style across the codebase.
+
+
 ### Examples
 
 Several example codes are provided.

--- a/examples/ex1_tensor/main.cpp
+++ b/examples/ex1_tensor/main.cpp
@@ -1,14 +1,13 @@
-#include<iostream>
-#include<tensor.h>
+#include <iostream>
+#include <tensor.h>
 
 using namespace std;
 
-int main()
-{
-    cout<<"hola mundo!"<<endl;
+int main() {
+  cout << "hola mundo!" << endl;
 
-    TensorD t({1,2,3});
-    t.FillRandu();
-    t.Save(cout);
-    return 0;
+  TensorD t({1, 2, 3});
+  t.FillRandu();
+  t.Save(cout);
+  return 0;
 }

--- a/examples/ex2_mpo/main.cpp
+++ b/examples/ex2_mpo/main.cpp
@@ -1,28 +1,25 @@
+#include "mps.h"
+#include <cassert>
 #include <iostream>
-#include"mps.h"
-#include<cassert>
 
 using namespace std;
 
-int main()
-{
-    cout << "Hello World!" << endl;
+int main() {
+  cout << "Hello World!" << endl;
 
-    MPS x(10,20);
-    x.FillRandu({20,2,20});
-        for(int i=0;i<2;i++)
-        {
-            x.PrintSizes();
-            int m=1;
-            for(auto t:x.M)
-            {
-                assert( t.dim[0]==m );
-                assert( t.dim[1]==2 );
-                assert( t.dim[2]<=x.m );
-                m=t.dim[2];
-            }
-            x.Canonicalize();
-        }
+  MPS x(10, 20);
+  x.FillRandu({20, 2, 20});
+  for (int i = 0; i < 2; i++) {
+    x.PrintSizes();
+    int m = 1;
+    for (auto t : x.M) {
+      assert(t.dim[0] == m);
+      assert(t.dim[1] == 2);
+      assert(t.dim[2] <= x.m);
+      m = t.dim[2];
+    }
+    x.Canonicalize();
+  }
 
-    return 0;
+  return 0;
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -83,7 +83,7 @@ Index IndexMul(const Index &dim1, const Index &dim2,
 //-------------------------------------------- string manipulation
 //------------------------------
 
-bool ArePermutation(std::string str1, std::string str2) {
+bool is_permutation(std::string str1, std::string str2) {
   auto s1 = str1;
   sort(s1.begin(), s1.end());
   auto s2 = str2;
@@ -94,7 +94,7 @@ bool ArePermutation(std::string str1, std::string str2) {
 std::vector<int> Permutation(std::string ini, std::string fin) {
   if (ini == fin)
     return {};
-  if (!ArePermutation(ini, fin))
+  if (!is_permutation(ini, fin))
     throw std::invalid_argument("Permutation: str1,str2 is not a permutation");
   std::vector<int> pos(ini.size());
   for (uint i = 0; i < ini.size(); i++)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1,124 +1,123 @@
-#include"index.h"
+#include "index.h"
 
 using namespace std;
 
-int Offset(Index id, Index dim)
-{
-    int sum=0,prod=1;
-    for(uint i=0;i<id.size();i++)
-    {
-        sum+=id[i]*prod;
-        prod*=dim[i];
-    }
-    return sum;
-}
-int Offset(Index id, Index dim,const std::vector<int>& posMap)
-{
-    int sum=0,prod=1;
-    for(uint i=0;i<id.size();i++)
-    {
-        sum+=id[posMap[i]]*prod;
-        prod*=dim[i];
-    }
-    return sum;
-}
-Index ToIndex(int pos,Index dim)
-{
-    Index id(dim.size());
-    for(int i=0;i<dim.size();i++)
-    {
-        id[i]=pos%dim[i];
-        pos/=dim[i];
-    }
-    return id;
+int Offset(Index id, Index dim) {
+  int sum = 0, prod = 1;
+  for (uint i = 0; i < id.size(); i++) {
+    sum += id[i] * prod;
+    prod *= dim[i];
+  }
+  return sum;
 }
 
-vector<Index> SplitIndex(Index dim,int splitPos)
-{
-    vector<Index> dim_v(2);
-    for(int i=0;i<splitPos;i++)
-        dim_v[0].push_back(dim[i]);
-    for(int i=splitPos;i<dim.size();i++)
-        dim_v[1].push_back(dim[i]);
-    for(auto& x:dim_v)
-        if (x.empty()) x.push_back({1});
-    return dim_v;
+int Offset(Index id, Index dim, const std::vector<int> &posMap) {
+  int sum = 0, prod = 1;
+  for (uint i = 0; i < id.size(); i++) {
+    sum += id[posMap[i]] * prod;
+    prod *= dim[i];
+  }
+  return sum;
 }
 
-vector<Index> SplitIndex(Index dim,vector<int> splitPos)
-{
-    vector<Index> dim_v(splitPos.size()+1);
-    uint p=0,s;
-    for(s=0;s<splitPos.size();s++)
-    {
-        for(int i=p;i<splitPos[s];i++)
-            dim_v[s].push_back(dim[i]);
-        p=splitPos[s];
-    }
-    for(uint i=p;i<dim.size();i++)
-        dim_v[s].push_back(dim[i]);
-    if (dim_v.front().empty()) dim_v.front().push_back({1});
-    if (dim_v.back() .empty()) dim_v.back() .push_back({1});
-    return dim_v;
+Index ToIndex(int pos, Index dim) {
+  Index id(dim.size());
+  for (int i = 0; i < dim.size(); i++) {
+    id[i] = pos % dim[i];
+    pos /= dim[i];
+  }
+  return id;
 }
 
-Index IndexReorder(const Index& dim, const std::vector<int> &posMap)
-{
-    Index dim2(dim.size());
-    for(int i=0;i<dim.size();i++)
-        dim2[posMap[i]]=dim[i];
-    return dim2;
+vector<Index> SplitIndex(Index dim, int splitPos) {
+  vector<Index> dim_v(2);
+  for (int i = 0; i < splitPos; i++)
+    dim_v[0].push_back(dim[i]);
+  for (int i = splitPos; i < dim.size(); i++)
+    dim_v[1].push_back(dim[i]);
+  for (auto &x : dim_v)
+    if (x.empty())
+      x.push_back({1});
+  return dim_v;
 }
 
-Index IndexMul(const Index& dim1,const Index& dim2,int nIdCommon) // Dim resulting from matrix multiplication
-{
-    for(int i=0;i<nIdCommon;i++)
-        if (dim1[dim1.size()-nIdCommon+i]!=dim2[i])
-            throw std::invalid_argument("Index:: IndexMul() incompatible dimensions");
-
-
-    Index dim_r;
-    for(int i=0;i<dim1.size()-nIdCommon;i++)
-        dim_r.push_back( dim1[i] );
-    for(int i=nIdCommon;i<dim2.size();i++)
-        dim_r.push_back( dim2[i] );
-    return dim_r;
+vector<Index> SplitIndex(Index dim, vector<int> splitPos) {
+  vector<Index> dim_v(splitPos.size() + 1);
+  uint p = 0, s;
+  for (s = 0; s < splitPos.size(); s++) {
+    for (int i = p; i < splitPos[s]; i++)
+      dim_v[s].push_back(dim[i]);
+    p = splitPos[s];
+  }
+  for (uint i = p; i < dim.size(); i++)
+    dim_v[s].push_back(dim[i]);
+  if (dim_v.front().empty())
+    dim_v.front().push_back({1});
+  if (dim_v.back().empty())
+    dim_v.back().push_back({1});
+  return dim_v;
 }
 
-//-------------------------------------------- string manipulation ------------------------------
-
-bool ArePermutation(std::string str1,std::string str2)
-{
-    auto s1=str1; sort(s1.begin(),s1.end());
-    auto s2=str2; sort(s2.begin(),s2.end());
-    return s1==s2;
+Index IndexReorder(const Index &dim, const std::vector<int> &posMap) {
+  Index dim2(dim.size());
+  for (int i = 0; i < dim.size(); i++)
+    dim2[posMap[i]] = dim[i];
+  return dim2;
 }
-std::vector<int> Permutation(std::string ini,std::string fin)
-{
-    if (ini==fin) return {};
-    if (!ArePermutation(ini,fin))
-        throw std::invalid_argument("Permutation: str1,str2 is not a permutation");
-    std::vector<int> pos(ini.size());
-    for(uint i=0;i<ini.size();i++)
-        pos[i]=fin.find(ini[i]);
-    return pos;
-}
-std::array<std::string,4> SortForMultiply(std::string str1,std::string str2)
-{
-    auto s1=str1; sort(s1.begin(),s1.end());
-    auto s2=str2; sort(s2.begin(),s2.end());
-    std::string sc;
-    std::set_intersection(s1.begin(),s1.end(),
-                          s2.begin(),s2.end(),
-                          std::back_inserter(sc));
-    s1.clear();
-    for(int i=0;i<str1.size();i++)
-        if (sc.find(str1[i])==std::string::npos)
-            s1.push_back(str1[i]);
 
-    s2.clear();
-    for(int i=0;i<str2.size();i++)
-        if (sc.find(str2[i])==std::string::npos)
-            s2.push_back(str2[i]);
-    return {s1+sc,sc+s2,s1+s2,sc};
+Index IndexMul(const Index &dim1, const Index &dim2,
+               int nIdCommon) // Dim resulting from matrix multiplication
+{
+  for (int i = 0; i < nIdCommon; i++)
+    if (dim1[dim1.size() - nIdCommon + i] != dim2[i])
+      throw std::invalid_argument("Index:: IndexMul() incompatible dimensions");
+
+  Index dim_r;
+  for (int i = 0; i < dim1.size() - nIdCommon; i++)
+    dim_r.push_back(dim1[i]);
+  for (int i = nIdCommon; i < dim2.size(); i++)
+    dim_r.push_back(dim2[i]);
+  return dim_r;
+}
+
+//-------------------------------------------- string manipulation
+//------------------------------
+
+bool ArePermutation(std::string str1, std::string str2) {
+  auto s1 = str1;
+  sort(s1.begin(), s1.end());
+  auto s2 = str2;
+  sort(s2.begin(), s2.end());
+  return s1 == s2;
+}
+
+std::vector<int> Permutation(std::string ini, std::string fin) {
+  if (ini == fin)
+    return {};
+  if (!ArePermutation(ini, fin))
+    throw std::invalid_argument("Permutation: str1,str2 is not a permutation");
+  std::vector<int> pos(ini.size());
+  for (uint i = 0; i < ini.size(); i++)
+    pos[i] = fin.find(ini[i]);
+  return pos;
+}
+
+std::array<std::string, 4> SortForMultiply(std::string str1, std::string str2) {
+  auto s1 = str1;
+  sort(s1.begin(), s1.end());
+  auto s2 = str2;
+  sort(s2.begin(), s2.end());
+  std::string sc;
+  std::set_intersection(s1.begin(), s1.end(), s2.begin(), s2.end(),
+                        std::back_inserter(sc));
+  s1.clear();
+  for (int i = 0; i < str1.size(); i++)
+    if (sc.find(str1[i]) == std::string::npos)
+      s1.push_back(str1[i]);
+
+  s2.clear();
+  for (int i = 0; i < str2.size(); i++)
+    if (sc.find(str2[i]) == std::string::npos)
+      s2.push_back(str2[i]);
+  return {s1 + sc, sc + s2, s1 + s2, sc};
 }

--- a/src/index.h
+++ b/src/index.h
@@ -38,7 +38,7 @@ Index IndexMul(const Index& dim1,const Index& dim2,int nIndCommon); // Dim resul
 
 //-------------------------------------- string manipulation ------------------------------
 
-bool ArePermutation(std::string str1,std::string str2);
+bool is_permutation(std::string str1,std::string str2);
 std::vector<int> Permutation(std::string str1,std::string str2);
 std::array<std::string,4> SortForMultiply(std::string str1,std::string str2);
 

--- a/src/mps.h
+++ b/src/mps.h
@@ -1,91 +1,92 @@
 #ifndef MPS_H
 #define MPS_H
 
-#include<iostream>
-#include<vector>
-#include"tensor.h"
+#include "tensor.h"
+#include <iostream>
+#include <vector>
 
-class MPS
-{
+class MPS {
+
 public:
-    std::vector<TensorD> M;
-    TensorD C;
-    int length,m;
-    double tol=1e-14;
+  std::vector<TensorD> M;
+  TensorD C;
+  int length, m;
+  double tol = 1e-14;
 
-    MPS(int length, int m)
-        :M(length),length(length),m(m)
-    {C==TensorD({1,1}, {1});}
+  MPS(int length, int m) : M(length), length(length), m(m) {
+    C == TensorD({1, 1}, {1});
+  }
 
-    void FillRandu(Index dim)
-    {
-        for(auto& x:M) x=TensorD(dim);
-        Index dl=dim; dl.front()=1;
-        Index dr=dim; dr.back()=1;
-        M.front()=TensorD(dl);
-        M.back ()=TensorD(dr);
+  void FillRandu(Index dim) {
+    for (auto &x : M)
+      x = TensorD(dim);
+    Index dl = dim;
+    dl.front() = 1;
+    Index dr = dim;
+    dr.back() = 1;
+    M.front() = TensorD(dl);
+    M.back() = TensorD(dr);
 
-        for(TensorD &x:M) x.FillRandu();
+    for (TensorD &x : M)
+      x.FillRandu();
+  }
+
+  void PrintSizes() const {
+    for (TensorD t : M) {
+      for (int x : t.dim)
+        std::cout << " " << x;
+      std::cout << ",";
     }
-    void PrintSizes() const
-    {
-        for(TensorD t:M)
-        {
-            for(int x:t.dim)
-                std::cout<<" "<<x;
-            std::cout<<",";
-        }
-        std::cout<<"\n";
-    }
-    void Canonicalize()
-    {
-        C=TensorD({1,1},{1});
-        pos=-1;
-        while(pos<length/2-1)
-            SweepRight();
-        auto cC=C;
-        C=TensorD({1,1},{1});
-        pos=length-1;
-        while(pos>length/2-1)
-            SweepLeft();
-        C=cC*C;
-        ExtractNorm(C);
-    }
-    void Normalize() {norm_n=1;}
-    void SweepRight()
-    {
-        pos++;
-        auto psi=C*M[pos];
-        ExtractNorm(psi);
-        auto usvt=SVDecomposition(psi,psi.rank()-1);
-        M[pos]=usvt[0];
-        C=usvt[1]*usvt[2];
-    }
-    void SweepLeft()
-    {
-        auto psi=M[pos]*C;
-        ExtractNorm(psi);
-        auto usvt=SVDecomposition(psi,1);
-        M[pos]=usvt[2];
-        C=usvt[0]*usvt[1];
-        pos--;
-    }
+    std::cout << "\n";
+  }
+
+  void Canonicalize() {
+    C = TensorD({1, 1}, {1});
+    pos = -1;
+    while (pos < length / 2 - 1)
+      SweepRight();
+    auto cC = C;
+    C = TensorD({1, 1}, {1});
+    pos = length - 1;
+    while (pos > length / 2 - 1)
+      SweepLeft();
+    C = cC * C;
+    ExtractNorm(C);
+  }
+
+  void Normalize() { norm_n = 1; }
+
+  void SweepRight() {
+    pos++;
+    auto psi = C * M[pos];
+    ExtractNorm(psi);
+    auto usvt = SVDecomposition(psi, psi.rank() - 1);
+    M[pos] = usvt[0];
+    C = usvt[1] * usvt[2];
+  }
+
+  void SweepLeft() {
+    auto psi = M[pos] * C;
+    ExtractNorm(psi);
+    auto usvt = SVDecomposition(psi, 1);
+    M[pos] = usvt[2];
+    C = usvt[0] * usvt[1];
+    pos--;
+  }
 
 private:
-    void ExtractNorm(TensorD& psi)
-    {
-        double nr=Norm(psi);
-        if (nr<tol)
-            throw std::logic_error("mps:ExtractNorm() null matrix");
-        norm_n*=pow(nr,1.0/M.size());
-        psi*=1.0/nr;
+  void ExtractNorm(TensorD &psi) {
+    double nr = Norm(psi);
+    if (nr < tol)
+      throw std::logic_error("mps:ExtractNorm() null matrix");
+    norm_n *= pow(nr, 1.0 / M.size());
+    psi *= 1.0 / nr;
 
-        norm_n*=pow(Norm(C),1.0/M.size());
-    }
+    norm_n *= pow(Norm(C), 1.0 / M.size());
+  }
 
-    int pos=-1;
-    double norm_n=1;                //norm(MPS)^(1/n)
-
+  int pos = -1;
+  double norm_n = 1; // norm(MPS)^(1/n)
 };
 
 #endif // MPS_H

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -1,8 +1,7 @@
 #ifndef TENSOR_CPP
 #define TENSOR_CPP
 
-#include"tensor.h"
-#include<algorithm>
-
+#include "tensor.h"
+#include <algorithm>
 
 #endif

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -1,325 +1,274 @@
 #ifndef TENSOR_H
 #define TENSOR_H
 
-#include<vector>
-#include<random>
-#include<iostream>
-#include<fstream>
-#include<array>
-#include<algorithm>
-#include<functional>
-#include<type_traits>
+#include <algorithm>
+#include <array>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <random>
+#include <type_traits>
+#include <vector>
 
-#include"utils.h"
-#include"index.h"
+#include "index.h"
+#include "utils.h"
 
-template<class T> class Tensor;
-template<class T> class TensorRef;
-template<class T> class TensorCRef;
-template<class T> class TensorRef2;
-template<class Tensor> struct TensorNotation;
+template <class T> class Tensor;
+template <class T> class TensorRef;
+template <class T> class TensorCRef;
+template <class T> class TensorRef2;
+template <class Tensor> struct TensorNotation;
 
-using TensorD=Tensor<double>;
+using TensorD = Tensor<double>;
 
+template <class T> struct Tensor {
+  typedef std::vector<T> C;
 
-template<class T>
-struct Tensor
-{
-    typedef std::vector<T> C;
+  Index dim;
 
-    Index  dim;
 private:
-    int n=0;
-    std::vector<T> _vec;
-    T* mem=nullptr;
+  int n = 0;
+  std::vector<T> _vec;
+  T *mem = nullptr;
+
 public:
-    T* data() {return mem==nullptr?_vec.data():mem;}
-    const T* data() const {return mem==nullptr?_vec.data():mem;}
-    int size() const {return n;}
+  T *data() { return mem == nullptr ? _vec.data() : mem; }
+  const T *data() const { return mem == nullptr ? _vec.data() : mem; }
+  int size() const { return n; }
 
-    C vec() const {return C(data(),data()+size());}
+  C vec() const { return C(data(), data() + size()); }
 
-    Tensor() {}
-    Tensor(const Index& dim)
-        :dim(dim),n(Prod(dim)),_vec(n) {}
-    Tensor(const Index& dim,const std::vector<T>& vec)
-        :dim(dim),n(Prod(dim)),_vec(vec)
-    {}
-    Tensor(const Index& dim,T* dat)
-        :dim(dim),n(Prod(dim)),mem(dat)
-    {}
+  Tensor() {}
+  Tensor(const Index &dim) : dim(dim), n(Prod(dim)), _vec(n) {}
+  Tensor(const Index &dim, const std::vector<T> &vec)
+      : dim(dim), n(Prod(dim)), _vec(vec) {}
+  Tensor(const Index &dim, T *dat) : dim(dim), n(Prod(dim)), mem(dat) {}
 
-    int rank() const {return dim.size();}
+  int rank() const { return dim.size(); }
 
-    void FillZeros()
-    {
-        VecFillZeros(data(),size());
-    }
-    void FillRandu()
-    {
-        VecFillRandu(data(),size());
-    }
+  void FillZeros() { VecFillZeros(data(), size()); }
+  void FillRandu() { VecFillRandu(data(), size()); }
 
-    T& operator[](const Index& id)
-    {
-        return (*this)[Offset(id,dim)];
-    }
-    const T& operator[](const Index& id) const
-    {
-        return (*this)[Offset(id,dim)];
-    }
-    T& operator[](int i)
-    {
-        return data()[i];
-    }
-    const T& operator[](int i) const
-    {
-        return data()[i];
-    }
+  T &operator[](const Index &id) { return (*this)[Offset(id, dim)]; }
+  const T &operator[](const Index &id) const {
+    return (*this)[Offset(id, dim)];
+  }
+  T &operator[](int i) { return data()[i]; }
+  const T &operator[](int i) const { return data()[i]; }
 
-    TensorNotation<Tensor&> operator()(std::string id)
-    {
-        return {*this,id};
-    }
-    TensorNotation<const Tensor&> operator()  (std::string id) const
-    {
-        return {*this,id};
-    }
+  TensorNotation<Tensor &> operator()(std::string id) { return {*this, id}; }
+  TensorNotation<const Tensor &> operator()(std::string id) const {
+    return {*this, id};
+  }
 
-    void Save(std::ostream& out) const
-    {
-        for(int x:dim) out<<x<<" ";
-        out<<"\n";
-        VecSave(data(),size(),out);
-    }
-    void Save(std::string filename) const
-    {
-        std::ofstream out(filename); Save(out);
-    }
-    void Load(std::istream& in)
-    {
-        for(int x:dim) in>>x;
-        VecLoad(data(),size(),in);
-    }
-    void Load(std::string filename)
-    {
-        std::ifstream in(filename);  Load(in);
-    }
+  void Save(std::ostream &out) const {
+    for (int x : dim)
+      out << x << " ";
+    out << "\n";
+    VecSave(data(), size(), out);
+  }
+  void Save(std::string filename) const {
+    std::ofstream out(filename);
+    Save(out);
+  }
+  void Load(std::istream &in) {
+    for (int x : dim)
+      in >> x;
+    VecLoad(data(), size(), in);
+  }
+  void Load(std::string filename) {
+    std::ifstream in(filename);
+    Load(in);
+  }
 
-    void operator*=(T c)
-    {
-        VecProd(data(),size(),c);
-    }
-    void operator+=(const Tensor& t2)
-    {
-        if (dim!=t2.dim)
-            throw std::invalid_argument("Tensor::operator-= incompatible");
+  void operator*=(T c) { VecProd(data(), size(), c); }
+  void operator+=(const Tensor &t2) {
+    if (dim != t2.dim)
+      throw std::invalid_argument("Tensor::operator-= incompatible");
 
-        VecPlusInplace(data(),t2.data(),size());
-    }
-    void operator-=(const Tensor& t2)
-    {
-        if (dim!=t2.dim)
-            throw std::invalid_argument("Tensor::operator-=incompatible");
+    VecPlusInplace(data(), t2.data(), size());
+  }
+  void operator-=(const Tensor &t2) {
+    if (dim != t2.dim)
+      throw std::invalid_argument("Tensor::operator-=incompatible");
 
-        VecMinusInplace(data(),t2.data(),size());
-    }
+    VecMinusInplace(data(), t2.data(), size());
+  }
 
-    Tensor operator-() const
-    {
-        Tensor y=*this;
-        VecNegativeInplace(y.data(),size());
-        return y;
-    }
-    Tensor operator*(T c) const
-    {
-        Tensor y=*this;
-        y*=c;
-        return y;
-    }
-    Tensor operator+(const Tensor& t2) const
-    {
-        Tensor y=*this;
-        y+=t2;
-        return y;
-    }
-    Tensor operator-(const Tensor& t2) const
-    {
-        Tensor y=*this;
-        y-=t2;
-        return y;
-    }
+  Tensor operator-() const {
+    Tensor y = *this;
+    VecNegativeInplace(y.data(), size());
+    return y;
+  }
+  Tensor operator*(T c) const {
+    Tensor y = *this;
+    y *= c;
+    return y;
+  }
+  Tensor operator+(const Tensor &t2) const {
+    Tensor y = *this;
+    y += t2;
+    return y;
+  }
+  Tensor operator-(const Tensor &t2) const {
+    Tensor y = *this;
+    y -= t2;
+    return y;
+  }
 
-    Tensor<T> ReShape(int splitPos)
-    {
-        auto dim_v=SplitIndex(dim,splitPos);
-        return {{ Prod(dim_v[0]), Prod(dim_v[1])}, data()};
-    }
-    Tensor<T> ReShape(int splitPos) const
-    {
-        auto dim_v=SplitIndex(dim,splitPos);
-        return {{ Prod(dim_v[0]), Prod(dim_v[1])}, const_cast<T*>(data())};
-    }
-    /*
-    Tensor<C&> ReShape(std::vector<int> splitPos)
-    {
-        auto dim_v=SplitIndex(dim,splitPos);
-        Index dimr(dim_v.size());
-        for(int i=0;i<dim_v.size();i++)
-            dimr[i]=Prod(dim_v[i]);
-        return TensorReShape<T>(dimr,v);
-    }
-    Tensor<const C&> ReShape(std::vector<int> splitPos) const
-    {
-        auto dim_v=SplitIndex(dim,splitPos);
-        Index dimr(dim_v.size());
-        for(int i=0;i<dim_v.size();i++)
-            dimr[i]=Prod(dim_v[i]);
-        return TensorReShapeC<T>(dimr,v);
-    }
-    */
+  Tensor<T> ReShape(int splitPos) {
+    auto dim_v = SplitIndex(dim, splitPos);
+    return {{Prod(dim_v[0]), Prod(dim_v[1])}, data()};
+  }
+  Tensor<T> ReShape(int splitPos) const {
+    auto dim_v = SplitIndex(dim, splitPos);
+    return {{Prod(dim_v[0]), Prod(dim_v[1])}, const_cast<T *>(data())};
+  }
+  /*
+  Tensor<C&> ReShape(std::vector<int> splitPos)
+  {
+      auto dim_v=SplitIndex(dim,splitPos);
+      Index dimr(dim_v.size());
+      for(int i=0;i<dim_v.size();i++)
+          dimr[i]=Prod(dim_v[i]);
+      return TensorReShape<T>(dimr,v);
+  }
+  Tensor<const C&> ReShape(std::vector<int> splitPos) const
+  {
+      auto dim_v=SplitIndex(dim,splitPos);
+      Index dimr(dim_v.size());
+      for(int i=0;i<dim_v.size();i++)
+          dimr[i]=Prod(dim_v[i]);
+      return TensorReShapeC<T>(dimr,v);
+  }
+  */
 
-    Tensor DiagMat() const
-    {
-        int n=size();
-        Tensor t2({n,n});
-        t2.FillZeros();
-        for(int i=0;i<n;i++)
-            t2[{i,i}]=data()[i];
-        return t2;
-    }
+  Tensor DiagMat() const {
+    int n = size();
+    Tensor t2({n, n});
+    t2.FillZeros();
+    for (int i = 0; i < n; i++)
+      t2[{i, i}] = data()[i];
+    return t2;
+  }
 
-    Tensor Reorder(std::vector<int> posMap) const
-    {
-        Tensor t(IndexReorder(dim,posMap));
-        for(int i=0;i<t.size();i++)
-        {
-//            int im=Offset(IndexReorder(ToIndex(i,dim),posMap),t.dim) ;
-            int im=Offset(ToIndex(i,t.dim),dim,posMap);
-            t[i]=(*this)[im];
-        }
-        return t;
+  Tensor Reorder(std::vector<int> posMap) const {
+    Tensor t(IndexReorder(dim, posMap));
+    for (int i = 0; i < t.size(); i++) {
+      //            int im=Offset(IndexReorder(ToIndex(i,dim),posMap),t.dim) ;
+      int im = Offset(ToIndex(i, t.dim), dim, posMap);
+      t[i] = (*this)[im];
     }
-    Tensor Reorder(std::string ini,std::string fin) const
-    {
-        if (ini==fin) return *this;
-        return Reorder(Permutation(ini,fin));
-    }
-    Tensor Transpose(int splitPos) const
-    {
-        auto dim_v=SplitIndex(dim,splitPos);
-        std::swap(dim_v[0],dim_v[1]);
-        Index dim2;
-        for(Index d:dim_v)
-            for(auto x:d)
-                dim2.push_back(x);
-        Tensor t2(dim2);
-        auto m1=ReShape(splitPos);
-        MatTranspose(m1.data(),t2.data(),m1.dim[0],m1.dim[1]);
-        return t2;
-    }
-    Tensor operator*(const Tensor& t2) const
-    {
-        return Multiply(t2,1);
-    }
-    Tensor Multiply(const Tensor& t2, int nIdCommon) const
-    {
-        const Tensor& t1=*this;
-        Index dim_r=IndexMul(t1.dim,t2.dim,nIdCommon);
-        Tensor t3(dim_r);
+    return t;
+  }
+  Tensor Reorder(std::string ini, std::string fin) const {
+    if (ini == fin)
+      return *this;
+    return Reorder(Permutation(ini, fin));
+  }
+  Tensor Transpose(int splitPos) const {
+    auto dim_v = SplitIndex(dim, splitPos);
+    std::swap(dim_v[0], dim_v[1]);
+    Index dim2;
+    for (Index d : dim_v)
+      for (auto x : d)
+        dim2.push_back(x);
+    Tensor t2(dim2);
+    auto m1 = ReShape(splitPos);
+    MatTranspose(m1.data(), t2.data(), m1.dim[0], m1.dim[1]);
+    return t2;
+  }
+  Tensor operator*(const Tensor &t2) const { return Multiply(t2, 1); }
+  Tensor Multiply(const Tensor &t2, int nIdCommon) const {
+    const Tensor &t1 = *this;
+    Index dim_r = IndexMul(t1.dim, t2.dim, nIdCommon);
+    Tensor t3(dim_r);
 
-        auto m1=t1.ReShape(t1.rank()-nIdCommon);  //Matrix operation
-        auto m2=t2.ReShape(nIdCommon);
-        auto m3=t3.ReShape(t1.rank()-nIdCommon);
-        MatMul(m1.data(),m2.data(),m3.data(),m1.dim[0],m1.dim[1],m2.dim[1]);
-        return t3;
-    }
+    auto m1 = t1.ReShape(t1.rank() - nIdCommon); // Matrix operation
+    auto m2 = t2.ReShape(nIdCommon);
+    auto m3 = t3.ReShape(t1.rank() - nIdCommon);
+    MatMul(m1.data(), m2.data(), m3.data(), m1.dim[0], m1.dim[1], m2.dim[1]);
+    return t3;
+  }
 
-    //---- friends ----
+  //---- friends ----
 
-    friend bool operator==(const Tensor& t1,const Tensor& t2) //esta mal
-    {
-        return ( t1.dim==t2.dim && t1.vec()==t2.vec() );
-    }
-    friend bool operator!=(const Tensor& t1,const Tensor& t2)
-    {
-        return !(t1==t2);
-    }
-    friend std::ostream& operator<<(std::ostream& out,const Tensor& M)
-    {
-        M.Save(out); return out;
-    }
-    friend std::istream& operator>>(std::istream& in,Tensor& t)
-    {
-        t.Load(in); return in;
-    }
-    friend T Dot(const Tensor& t1,const Tensor& t2)
-    {
-        return VecDot(t1.data(),t2.data(),t1.size());
-    }
-    friend double Norm(const Tensor& t)
-    {
-        return VecNorm(t.data(),t.size());
-    }
-    friend std::array<Tensor,2> EigenDecomposition(const Tensor& t,int splitPos)
-    {
-        auto mt=t.ReShape(splitPos);
-        if (mt.dim[0]!=mt.dim[1])
-            throw std::invalid_argument("Tensor:: EigenDecomposition non-square matrix");
-        int n=mt.dim[0];
-        auto dimEvec=SplitIndex(t.dim,splitPos)[0];
-        dimEvec.push_back(n);    //evec dimension
-        auto evec=Tensor(dimEvec);
-        auto eval=Tensor({n});
-        MatFullDiag(mt.data(),n,evec.data(),eval.data());
-        return {evec,eval};
-    }
-    friend std::vector<Tensor> SVDecomposition(const Tensor& t,int splitPos) //M=U*S*Vt
-    {
-        auto mt=t.ReShape(splitPos);
-        int n=std::min(mt.dim[0],mt.dim[1]);
-        auto dimUV=SplitIndex(t.dim,splitPos);
-        dimUV[0].push_back(n);    //U dimension
-        dimUV[1].push_back(n);    //V dimension
-        auto U=Tensor(dimUV[0]); U.FillZeros();
-        auto S=Tensor({n});      S.FillZeros();
-        auto V=Tensor(dimUV[1]); V.FillZeros();
-        MatSVD(mt.data(),mt.dim[0],mt.dim[1],U.data(),S.data(),V.data());
-        return {U,S.DiagMat(),V.Transpose(V.rank()-1)};
-    }
+  friend bool operator==(const Tensor &t1, const Tensor &t2) // esta mal
+  {
+    return (t1.dim == t2.dim && t1.vec() == t2.vec());
+  }
+  friend bool operator!=(const Tensor &t1, const Tensor &t2) {
+    return !(t1 == t2);
+  }
+  friend std::ostream &operator<<(std::ostream &out, const Tensor &M) {
+    M.Save(out);
+    return out;
+  }
+  friend std::istream &operator>>(std::istream &in, Tensor &t) {
+    t.Load(in);
+    return in;
+  }
+  friend T Dot(const Tensor &t1, const Tensor &t2) {
+    return VecDot(t1.data(), t2.data(), t1.size());
+  }
+  friend double Norm(const Tensor &t) { return VecNorm(t.data(), t.size()); }
+  friend std::array<Tensor, 2> EigenDecomposition(const Tensor &t,
+                                                  int splitPos) {
+    auto mt = t.ReShape(splitPos);
+    if (mt.dim[0] != mt.dim[1])
+      throw std::invalid_argument(
+          "Tensor:: EigenDecomposition non-square matrix");
+    int n = mt.dim[0];
+    auto dimEvec = SplitIndex(t.dim, splitPos)[0];
+    dimEvec.push_back(n); // evec dimension
+    auto evec = Tensor(dimEvec);
+    auto eval = Tensor({n});
+    MatFullDiag(mt.data(), n, evec.data(), eval.data());
+    return {evec, eval};
+  }
+  friend std::vector<Tensor> SVDecomposition(const Tensor &t,
+                                             int splitPos) // M=U*S*Vt
+  {
+    auto mt = t.ReShape(splitPos);
+    int n = std::min(mt.dim[0], mt.dim[1]);
+    auto dimUV = SplitIndex(t.dim, splitPos);
+    dimUV[0].push_back(n); // U dimension
+    dimUV[1].push_back(n); // V dimension
+    auto U = Tensor(dimUV[0]);
+    U.FillZeros();
+    auto S = Tensor({n});
+    S.FillZeros();
+    auto V = Tensor(dimUV[1]);
+    V.FillZeros();
+    MatSVD(mt.data(), mt.dim[0], mt.dim[1], U.data(), S.data(), V.data());
+    return {U, S.DiagMat(), V.Transpose(V.rank() - 1)};
+  }
 };
 
+template <class Tensor> struct TensorNotation {
+  typedef typename std::decay<Tensor>::type _Tensor;
 
-template<class Tensor>
-struct TensorNotation
-{
-    typedef typename std::decay<Tensor>::type _Tensor;
+  Tensor t;
+  std::string id;
 
-    Tensor t;
-    std::string id;
+  TensorNotation(Tensor t, std::string id) : t(t), id(id) {}
 
-    TensorNotation(Tensor t,std::string id)
-        :t(t),id(id) {}
-
-    template<class Tensor2>
-    TensorNotation& operator=(const TensorNotation<Tensor2>& tn)
-    {
-        t=tn.t.Reorder(tn.id,id);
-        return *this;
-    }
-    template<class Tensor2>
-    TensorNotation<_Tensor> operator*(const TensorNotation<Tensor2>& tn)
-    {
-        auto ids=SortForMultiply(id,tn.id);
-        auto t1=   t.Reorder(id   ,ids[0]);
-        auto t2=tn.t.Reorder(tn.id,ids[1]);
-        int nc=ids[3].length();
-        auto t3=t1.Multiply(t2,nc);
-        return {t3, ids[2]};
-    }
+  template <class Tensor2>
+  TensorNotation &operator=(const TensorNotation<Tensor2> &tn) {
+    t = tn.t.Reorder(tn.id, id);
+    return *this;
+  }
+  template <class Tensor2>
+  TensorNotation<_Tensor> operator*(const TensorNotation<Tensor2> &tn) {
+    auto ids = SortForMultiply(id, tn.id);
+    auto t1 = t.Reorder(id, ids[0]);
+    auto t2 = tn.t.Reorder(tn.id, ids[1]);
+    int nc = ids[3].length();
+    auto t3 = t1.Multiply(t2, nc);
+    return {t3, ids[2]};
+  }
 };
 
-
-#include"tensor.cpp"   // implementations
+#include "tensor.cpp" // implementations
 
 #endif // TENSOR_H

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,38 +1,35 @@
 #include "utils.h"
-#include<armadillo>
+#include <armadillo>
 
 using namespace std;
 using namespace arma;
 
-void MatTranspose(const double*  X, double *result, int nrow, int ncol)
-{
-    const mat mX((double* const)X,nrow,ncol,false);
-    mat res(result,ncol,nrow,false);
-    res=mX.t();
+void MatTranspose(const double *X, double *result, int nrow, int ncol) {
+  const mat mX((double *const)X, nrow, ncol, false);
+  mat res(result, ncol, nrow, false);
+  res = mX.t();
 }
 
-void MatMul(const double*  mat1, const double*  mat2, double *result, int nrow1, int ncol1, int ncol2)
-{
-    const mat m1((double* const)mat1,nrow1,ncol1,false);
-    const mat m2((double* const)mat2,ncol1,ncol2,false);
-    mat res(result,nrow1,ncol2,false);
-    res=m1*m2;
+void MatMul(const double *mat1, const double *mat2, double *result, int nrow1,
+            int ncol1, int ncol2) {
+  const mat m1((double *const)mat1, nrow1, ncol1, false);
+  const mat m2((double *const)mat2, ncol1, ncol2, false);
+  mat res(result, nrow1, ncol2, false);
+  res = m1 * m2;
 }
 
-void MatFullDiag(double* const X,int n,double *evec,double *eval)
-{
-    const mat mX(X,n,n,false);
-    mat mevec(evec,n,n,false);
-    vec meval(eval,n,false);
-    eig_sym(meval,mevec,mX);
+void MatFullDiag(double *const X, int n, double *evec, double *eval) {
+  const mat mX(X, n, n, false);
+  mat mevec(evec, n, n, false);
+  vec meval(eval, n, false);
+  eig_sym(meval, mevec, mX);
 }
 
-void MatSVD(const double*  X, int m,int n,double *U,double *S,double *V)
-{
-    const mat mX((double* const)X,m,n,false);
-    int ns=std::min(m,n);
-    mat mU(U,m,ns,false);
-    vec vS(S,ns,false);
-    mat mV(V,n,ns,false);
-    svd_econ(mU, vS, mV, mX);
+void MatSVD(const double *X, int m, int n, double *U, double *S, double *V) {
+  const mat mX((double *const)X, m, n, false);
+  int ns = std::min(m, n);
+  mat mU(U, m, ns, false);
+  vec vS(S, ns, false);
+  mat mV(V, n, ns, false);
+  svd_econ(mU, vS, mV, mX);
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,10 +1,9 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-#include<iostream>
+#include <iostream>
 
-TEST_CASE( "hola", "[main]" )
-{
-    std::cout<<"hola mundo\n";
-    REQUIRE( true );
+TEST_CASE("hola", "[main]") {
+  std::cout << "hola mundo\n";
+  REQUIRE(true);
 }

--- a/tests/test_mps.cpp
+++ b/tests/test_mps.cpp
@@ -1,30 +1,24 @@
+#include "catch.hpp"
 #include "mps.h"
-#include"catch.hpp"
 
-
-TEST_CASE( "mps canonization", "[mps]" )
-{
-    MPS x(20,3);
-    x.FillRandu({3,2,3});
-    SECTION( "initialization and compatibility" )
-    {
-        for(int i=0;i<2;i++)
-        {
-            x.PrintSizes();
-            int m=1;
-            for(auto t:x.M)
-            {
-                REQUIRE( t.dim[0]==m );
-                REQUIRE( t.dim[1]==2 );
-                REQUIRE( t.dim[2]<=x.m );
-                m=t.dim[2];
-            }
-            x.Canonicalize();
-        }
+TEST_CASE("mps canonization", "[mps]") {
+  MPS x(20, 3);
+  x.FillRandu({3, 2, 3});
+  SECTION("initialization and compatibility") {
+    for (int i = 0; i < 2; i++) {
+      x.PrintSizes();
+      int m = 1;
+      for (auto t : x.M) {
+        REQUIRE(t.dim[0] == m);
+        REQUIRE(t.dim[1] == 2);
+        REQUIRE(t.dim[2] <= x.m);
+        m = t.dim[2];
+      }
+      x.Canonicalize();
     }
-    SECTION( "norm" )
-    {
-        x.Canonicalize();
-        REQUIRE( Norm(x.C)==1 );
-    }
+  }
+  SECTION("norm") {
+    x.Canonicalize();
+    REQUIRE(Norm(x.C) == 1);
+  }
 }

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -11,9 +11,7 @@ TEST_CASE("tensor level 1", "[tensor]") {
   TensorD t({d[0], d[1], d[2]});
   t.FillRandu();
 
-  SECTION("size") { 
-    REQUIRE(t.size() == d[0] * d[1] * d[2]); 
-  }
+  SECTION("size") { REQUIRE(t.size() == d[0] * d[1] * d[2]); }
 
   SECTION("fill") {
     t.FillZeros();

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -1,114 +1,113 @@
+#include "catch.hpp"
 #include "tensor.h"
-#include"catch.hpp"
 
-#include<armadillo>
+#include <armadillo>
 
 using namespace std;
 using namespace arma;
 
-TEST_CASE( "tensor level 1", "[tensor]" )
-{
-    int d[]={2,3,2};
-    TensorD t({d[0],d[1],d[2]});
+TEST_CASE("tensor level 1", "[tensor]") {
+  int d[] = {2, 3, 2};
+  TensorD t({d[0], d[1], d[2]});
+  t.FillRandu();
+
+  SECTION("size") { 
+    REQUIRE(t.size() == d[0] * d[1] * d[2]); 
+  }
+
+  SECTION("fill") {
+    t.FillZeros();
+    REQUIRE(t[{1, 1, 1}] == 0);
     t.FillRandu();
-    SECTION( "size" )
-    {
-        REQUIRE( t.size() == d[0]*d[1]*d[2] );
-    }
-    SECTION( "fill" )
-    {
-        t.FillZeros();
-        REQUIRE( t[{1,1,1}]==0 );
-        t.FillRandu();
-        REQUIRE( t[{1,1,1}]!=0 );
-    }
-    SECTION( "assign" )
-    {
-        t[{1,1,1}]=43;
-        REQUIRE( t[{1,1,1}]==43 );
-    }
-    SECTION( "save/load" )
-    {
-        auto &t1=t;
-        t1.Save("t1.txt");
-        TensorD t2(t1.dim);
-        t2.Load("t1.txt");
-        t2.Save("t2.txt");
-        REQUIRE( t1==t2 );
-    }
-    SECTION( "copy/operator=" )
-    {
-        TensorD t3(t.dim);
-        {
-            TensorD t2=t;
-            REQUIRE( t==t2 );
-            t3=t2;
-        }
-        REQUIRE( t==t3 );
-    }
-    SECTION( "ReShape" )
-    {
-        auto t2=t.ReShape(2);
-        REQUIRE( t.vec()==t2.vec() );
-        REQUIRE( t2.dim==Index({6,2}) );
-        t2.data()[10]=123;
-        REQUIRE( t.data()[10]==123 );
+    REQUIRE(t[{1, 1, 1}] != 0);
+  }
 
-        auto t3=t2.ReShape(2).ReShape(1);
-        REQUIRE( t3.dim==Index({12,1}) );
-        t3.data()[10]=321;
-        REQUIRE( t.data()[10]==321 );
+  SECTION("assign") {
+    t[{1, 1, 1}] = 43;
+    REQUIRE(t[{1, 1, 1}] == 43);
+  }
 
-        auto t5=t3;
-        t5[10]=456;
-        REQUIRE( t[10]==456 );
+  SECTION("save/load") {
+    auto &t1 = t;
+    t1.Save("t1.txt");
+    TensorD t2(t1.dim);
+    t2.Load("t1.txt");
+    t2.Save("t2.txt");
+    REQUIRE(t1 == t2);
+  }
 
-        TensorD t6(t.dim); t6.FillZeros();
-        t6+=t;
-        REQUIRE( t6==t );
-    }
-    SECTION( "operator-/Norm" )
+  SECTION("copy/operator=") {
+    TensorD t3(t.dim);
     {
-        auto dt=t-t;
-        REQUIRE( Norm(dt)<1e-16 );
+      TensorD t2 = t;
+      REQUIRE(t == t2);
+      t3 = t2;
     }
-    SECTION( "operator+" )
-    {
-        auto t2=-t;
-        auto dt2=t2+t;
-        REQUIRE( Norm(dt2)<1e-16 );
-    }
-    SECTION( "matrix transpose" )
-    {
-        TensorD t2=t.Transpose(1);
-        REQUIRE( t2.dim==Index{3,2,2} );
-        auto mt=t.ReShape(1);
-        auto mt2=t2.ReShape(t2.rank()-1);
-        for(int i=0;i<mt.dim[0];i++)
-            for(int j=0;j<mt.dim[1];j++)
-                REQUIRE( mt[{i,j}]==mt2[{j,i}] );
-    }
-    SECTION( "matrix multiplication" )
-    {
-        TensorD t2=t*t;
-        REQUIRE( t2.dim==Index{d[0],d[1],d[1],d[2]} );
+    REQUIRE(t == t3);
+  }
 
-        mat A(t.data(),6,2);     // Checking result against armadillo
-        mat B(t.data(),2,6);
-        mat C=A*B;
-        vector<double> data(C.begin(),C.end());
+  SECTION("ReShape") {
+    auto t2 = t.ReShape(2);
+    REQUIRE(t.vec() == t2.vec());
+    REQUIRE(t2.dim == Index({6, 2}));
+    t2.data()[10] = 123;
+    REQUIRE(t.data()[10] == 123);
 
-        REQUIRE( data==t2.vec() );
-    }
-    SECTION( "matrix decomposition: svd" )
-    {
-        auto usvt=SVDecomposition(t,2);
-        REQUIRE( usvt[0].dim==Index{d[0],d[1],d[2]} );
-        REQUIRE( usvt[1].dim==Index{d[2],d[2]} );
-        REQUIRE( usvt[2].dim==Index{d[2],d[2]} );
+    auto t3 = t2.ReShape(2).ReShape(1);
+    REQUIRE(t3.dim == Index({12, 1}));
+    t3.data()[10] = 321;
+    REQUIRE(t.data()[10] == 321);
 
-        auto x=usvt[0]*usvt[1]*usvt[2];
-        REQUIRE( Norm(x-t)<1e-15 );
-    }
+    auto t5 = t3;
+    t5[10] = 456;
+    REQUIRE(t[10] == 456);
 
+    TensorD t6(t.dim);
+    t6.FillZeros();
+    t6 += t;
+    REQUIRE(t6 == t);
+  }
+
+  SECTION("operator-/Norm") {
+    auto dt = t - t;
+    REQUIRE(Norm(dt) < 1e-16);
+  }
+
+  SECTION("operator+") {
+    auto t2 = -t;
+    auto dt2 = t2 + t;
+    REQUIRE(Norm(dt2) < 1e-16);
+  }
+
+  SECTION("matrix transpose") {
+    TensorD t2 = t.Transpose(1);
+    REQUIRE(t2.dim == Index{3, 2, 2});
+    auto mt = t.ReShape(1);
+    auto mt2 = t2.ReShape(t2.rank() - 1);
+    for (int i = 0; i < mt.dim[0]; i++)
+      for (int j = 0; j < mt.dim[1]; j++)
+        REQUIRE(mt[{i, j}] == mt2[{j, i}]);
+  }
+
+  SECTION("matrix multiplication") {
+    TensorD t2 = t * t;
+    REQUIRE(t2.dim == Index{d[0], d[1], d[1], d[2]});
+
+    mat A(t.data(), 6, 2); // Checking result against armadillo
+    mat B(t.data(), 2, 6);
+    mat C = A * B;
+    vector<double> data(C.begin(), C.end());
+
+    REQUIRE(data == t2.vec());
+  }
+
+  SECTION("matrix decomposition: svd") {
+    auto usvt = SVDecomposition(t, 2);
+    REQUIRE(usvt[0].dim == Index{d[0], d[1], d[2]});
+    REQUIRE(usvt[1].dim == Index{d[2], d[2]});
+    REQUIRE(usvt[2].dim == Index{d[2], d[2]});
+
+    auto x = usvt[0] * usvt[1] * usvt[2];
+    REQUIRE(Norm(x - t) < 1e-15);
+  }
 }

--- a/tests/test_tensor_notation.cpp
+++ b/tests/test_tensor_notation.cpp
@@ -1,72 +1,64 @@
+#include "catch.hpp"
 #include "tensor.h"
-#include"catch.hpp"
 
-#include<string>
+#include <string>
 
 using namespace std;
 
-TEST_CASE( "tensor notation", "[tnotation]" )
-{
-    SECTION( "Indices are permutation" )
-    {
-        REQUIRE( ArePermutation("ijkl","ilkj")==true );
-        REQUIRE( ArePermutation("ijkl","ilj")==false );
-        REQUIRE( ArePermutation("ijkl","iljki")==false );
-        REQUIRE( ArePermutation("ijkl","lkji")==true );
-        REQUIRE( ArePermutation("ijkl","lkjig")==false );
-    }
-    SECTION( "Indices permutation to vector of pos" )
-    {
-        REQUIRE( Permutation("ijkl","ilkj")==vector<int>({0,3,2,1}) );
-        REQUIRE( Permutation("ijkl","lkji")==vector<int>({3,2,1,0}) );
-        REQUIRE( Permutation("ikl","lki")==vector<int>({2,1,0}) );
-        REQUIRE( Permutation("ijk","jki")==vector<int>({2,0,1}) );
-    }
-    TensorD t({2,3,2}), t2;
-    t.FillRandu();
-    const auto t1=t;
-    SECTION( "matrix transpose" )
-    {
-        t2("nml")=t1("mln");            //t2=t1.Reorder("mln","nml");
-        REQUIRE( t2==t1.Transpose(2));
-    }
-    SECTION( "matrix multiplication one common index" )
-    {
-        t2("ijlm")=t1("ijk") * t1("klm");
+TEST_CASE("tensor notation", "[tnotation]") {
+  SECTION("Indices are permutation") {
+    REQUIRE(ArePermutation("ijkl", "ilkj") == true);
+    REQUIRE(ArePermutation("ijkl", "ilj") == false);
+    REQUIRE(ArePermutation("ijkl", "iljki") == false);
+    REQUIRE(ArePermutation("ijkl", "lkji") == true);
+    REQUIRE(ArePermutation("ijkl", "lkjig") == false);
+  }
+  SECTION("Indices permutation to vector of pos") {
+    REQUIRE(Permutation("ijkl", "ilkj") == vector<int>({0, 3, 2, 1}));
+    REQUIRE(Permutation("ijkl", "lkji") == vector<int>({3, 2, 1, 0}));
+    REQUIRE(Permutation("ikl", "lki") == vector<int>({2, 1, 0}));
+    REQUIRE(Permutation("ijk", "jki") == vector<int>({2, 0, 1}));
+  }
+  TensorD t({2, 3, 2}), t2;
+  t.FillRandu();
+  const auto t1 = t;
+  SECTION("matrix transpose") {
+    t2("nml") = t1("mln"); // t2=t1.Reorder("mln","nml");
+    REQUIRE(t2 == t1.Transpose(2));
+  }
+  SECTION("matrix multiplication one common index") {
+    t2("ijlm") = t1("ijk") * t1("klm");
 
-        REQUIRE( t2.dim==Index{2,3,3,2} );
-        REQUIRE( t2.vec()==(t1*t1).vec() );
+    REQUIRE(t2.dim == Index{2, 3, 3, 2});
+    REQUIRE(t2.vec() == (t1 * t1).vec());
 
-        t2("ijln")=t1("ijk") * t1("klm") * t1.ReShape(1)("mn");
-        REQUIRE( t2.dim==Index{2,3,3,6} );
-        REQUIRE( t2.vec()==(t1*t1*t1.ReShape(1)).vec() );
-    }
-    SECTION( "matrix multiplication multi-index in common" )
-    {
-        t2("il")=t1("ijk") * t1("ljk");
+    t2("ijln") = t1("ijk") * t1("klm") * t1.ReShape(1)("mn");
+    REQUIRE(t2.dim == Index{2, 3, 3, 6});
+    REQUIRE(t2.vec() == (t1 * t1 * t1.ReShape(1)).vec());
+  }
+  SECTION("matrix multiplication multi-index in common") {
+    t2("il") = t1("ijk") * t1("ljk");
 
-        REQUIRE( t2.dim==Index{2,2} );
-        REQUIRE( t2.vec()==(t1.ReShape(1)*t1.ReShape(1).Transpose(1)).vec() );
+    REQUIRE(t2.dim == Index{2, 2});
+    REQUIRE(t2.vec() == (t1.ReShape(1) * t1.ReShape(1).Transpose(1)).vec());
 
-        t2("ijln")=t1("ijk") * t1("klm") * t1.ReShape(1)("mn");
-        REQUIRE( t2.dim==Index{2,3,3,6} );
-        REQUIRE( t2.vec()==(t1*t1*t1.ReShape(1)).vec() );
-    }
-    SECTION( "contraction and reorder" )
-    {
-        t2("lmij")=t1("ijk") * t1("klm");
+    t2("ijln") = t1("ijk") * t1("klm") * t1.ReShape(1)("mn");
+    REQUIRE(t2.dim == Index{2, 3, 3, 6});
+    REQUIRE(t2.vec() == (t1 * t1 * t1.ReShape(1)).vec());
+  }
+  SECTION("contraction and reorder") {
+    t2("lmij") = t1("ijk") * t1("klm");
 
-        REQUIRE( t2.dim==Index{3,2,2,3} );
-        REQUIRE( t2.vec()==(t1*t1).Transpose(2).vec() );
+    REQUIRE(t2.dim == Index{3, 2, 2, 3});
+    REQUIRE(t2.vec() == (t1 * t1).Transpose(2).vec());
 
-        t2("mlij")=t1("ijk") * t1("mlk");
+    t2("mlij") = t1("ijk") * t1("mlk");
 
-        REQUIRE( t2.dim==Index{2,3,2,3} );
-        REQUIRE( t2.vec()==(t1*t1.Transpose(2)).Transpose(2).vec() );
+    REQUIRE(t2.dim == Index{2, 3, 2, 3});
+    REQUIRE(t2.vec() == (t1 * t1.Transpose(2)).Transpose(2).vec());
 
-        t2("ikml")=t1("ijk") * t1("ljm");
+    t2("ikml") = t1("ijk") * t1("ljm");
 
-        REQUIRE( t2.dim==Index{2,2,2,2} );
-    }
-
+    REQUIRE(t2.dim == Index{2, 2, 2, 2});
+  }
 }

--- a/tests/test_tensor_notation.cpp
+++ b/tests/test_tensor_notation.cpp
@@ -7,11 +7,11 @@ using namespace std;
 
 TEST_CASE("tensor notation", "[tnotation]") {
   SECTION("Indices are permutation") {
-    REQUIRE(ArePermutation("ijkl", "ilkj") == true);
-    REQUIRE(ArePermutation("ijkl", "ilj") == false);
-    REQUIRE(ArePermutation("ijkl", "iljki") == false);
-    REQUIRE(ArePermutation("ijkl", "lkji") == true);
-    REQUIRE(ArePermutation("ijkl", "lkjig") == false);
+    REQUIRE(is_permutation("ijkl", "ilkj") == true);
+    REQUIRE(is_permutation("ijkl", "ilj") == false);
+    REQUIRE(is_permutation("ijkl", "iljki") == false);
+    REQUIRE(is_permutation("ijkl", "lkji") == true);
+    REQUIRE(is_permutation("ijkl", "lkjig") == false);
   }
   SECTION("Indices permutation to vector of pos") {
     REQUIRE(Permutation("ijkl", "ilkj") == vector<int>({0, 3, 2, 1}));


### PR DESCRIPTION
With this PR I ran clang-format in the whole codebase and added a script to run it easily. It will format the codebase using a consistent style.

I also went ahead and renamed the ugly `ArePermutation` to `is_permutation`.
I recommend you to go ahead and adopt this naming convention in which:
* class methods and standalone functions are names using [snake case](https://en.wikipedia.org/wiki/Snake_case) and
* classes are named using [PascalCase](https://en.wikipedia.org/wiki/Camel_case). 

The rest I think clang-format takes care of and you dont need to worry about it
